### PR TITLE
Fix timestamp generation

### DIFF
--- a/conduit/apps/authentication/models.py
+++ b/conduit/apps/authentication/models.py
@@ -132,7 +132,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         token = jwt.encode({
             'id': self.pk,
-            'exp': int(dt.strftime('%s'))
+            'exp': int(dt.timestamp())
         }, settings.SECRET_KEY, algorithm='HS256')
 
         return token.decode('utf-8')


### PR DESCRIPTION
The generation of a timestamp using dt.strftime('%S') does not work on all platforms. This fixes that.